### PR TITLE
Support string output paths in create_image

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,14 @@
 from PIL import Image
 import os
-from typing import Optional
+from typing import Optional, Union
 from pathlib import Path
 
 
 def create_image(
-    width: int, height: int, color_code: str, output_dir: Optional[Path] = None
+    width: int,
+    height: int,
+    color_code: str,
+    output_dir: Optional[Union[str, Path]] = None,
 ) -> None:
     """
     Create and save an image with the specified dimensions and color.
@@ -14,7 +17,9 @@ def create_image(
         width (int): The width of the image in pixels.
         height (int): The height of the image in pixels.
         color_code (str): The HTML color code for the image background.
-        output_dir (Optional[Path]): The directory to save the image. Defaults to "output_files".
+        output_dir (Optional[Union[str, Path]]):
+            The directory to save the image. Accepts a string path or
+            ``pathlib.Path``. Defaults to "output_files".
 
     Returns:
         None
@@ -30,6 +35,10 @@ def create_image(
     # Set the default output directory if not provided
     if output_dir is None:
         output_dir = Path("output_files")
+
+    # Convert string paths to Path objects
+    if isinstance(output_dir, str):
+        output_dir = Path(output_dir)
 
     # Create an image with the given color
     img = Image.new("RGB", (width, height), color=color_code)

--- a/test_image_creation.py
+++ b/test_image_creation.py
@@ -64,3 +64,11 @@ def test_output_directory_creation(tmp_path: Path) -> None:
     output_dir = tmp_path / "output_files"
     create_image(width, height, color_code, output_dir)
     assert output_dir.exists()
+
+
+def test_string_output_dir(tmp_path: Path) -> None:
+    """Ensure create_image works when output_dir is provided as a string."""
+    width, height, color_code = 50, 50, "#00FF00"
+    output_dir = tmp_path / "string_output"
+    create_image(width, height, color_code, str(output_dir))
+    assert (output_dir / "00FF00.jpg").exists()


### PR DESCRIPTION
## Summary
- update type hints and docstring in `create_image`
- coerce string `output_dir` into a `Path`
- test creating images when `output_dir` is a string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b55d3904c832190a16d75c9a97c35