### PR TITLE
Clarify output filename in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ This Python script generates a JPEG image of a specified size and color.
 
 You will be prompted to enter the width and height of the image, and the color code in HTML format (e.g., #FFFFFF for white).
 
-The script will create an image of the specified size and color, and save it as a JPEG file in the output_files directory. The filename will be the color code that you entered.
+The script will create an image of the specified size and color, and save it as a JPEG file in the output_files directory. The filename will be the color code without the leading '#'.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document that the saved filename omits the leading `#` from the chosen colour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b55d38d0483218195a5bec42df61c